### PR TITLE
Encapsulate ShaderProgram: Add Use() and 3 overloads of SetUniform()

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,7 @@
 [requires]
 glad/0.1.34
 glfw/3.3.2-3327050c@jkuhn/patched
+glm/0.9.9.8
 gtest/1.10.0
 
 [generators]

--- a/src/Graphics/OpenGL/IOpenGLWrapper.h
+++ b/src/Graphics/OpenGL/IOpenGLWrapper.h
@@ -21,6 +21,11 @@ namespace Graphics::OpenGL
         virtual void GetProgramiv(GLuint program, GLenum pname, GLint *params) = 0;
         virtual void GetProgramInfoLog(GLuint program, GLsizei maxLength, GLsizei* length, GLchar* infoLog) = 0;
         virtual void DeleteProgram(GLuint program) = 0;
+        virtual void UseProgram(GLuint program) = 0;
+        virtual GLint GetUniformLocation(GLuint program, const GLchar* location) = 0;
+        virtual void Uniform1i(GLint location, GLint v0) = 0;
+        virtual void UniformMatrix4fv(GLint location, GLsizei count, GLboolean transpose, const GLfloat *value) = 0;
+        virtual void Uniform3fv(GLint location, GLsizei count, const GLfloat *value) = 0;
 
         virtual void GenVertexArrays(GLsizei n, GLuint* arrays) = 0;
 
@@ -31,5 +36,6 @@ namespace Graphics::OpenGL
         virtual void TexParameteri(GLenum target, GLenum pname, GLint param) = 0;
         virtual void TexImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width,
             GLsizei height, GLint border, GLenum format, GLenum type, const void * data) = 0;
+
     };
 }

--- a/src/Graphics/OpenGL/OpenGLWrapper.h
+++ b/src/Graphics/OpenGL/OpenGLWrapper.h
@@ -74,6 +74,31 @@ namespace Graphics::OpenGL
             glDeleteProgram(program);
         }
 
+        void UseProgram(GLuint program) override
+        {
+            glUseProgram(program);
+        }
+
+        GLint GetUniformLocation(GLuint program, const GLchar* location) override
+        {
+            return glGetUniformLocation(program, location);
+        }
+
+        void Uniform1i(GLint location, GLint v0) override
+        {
+            glUniform1i(location, v0);
+        }
+
+        void UniformMatrix4fv(GLint location, GLsizei count, GLboolean transpose, const GLfloat *value) override
+        {
+            glUniformMatrix4fv(location, count, transpose, value);
+        }
+
+        void Uniform3fv(GLint location, GLsizei count, const GLfloat *value) override
+        {
+            glUniform3fv(location, count, value);
+        }
+
         void GenVertexArrays(GLsizei n, GLuint *arrays) override
         {
             glGenVertexArrays(n, arrays);

--- a/src/Graphics/OpenGL/ShaderProgram.cpp
+++ b/src/Graphics/OpenGL/ShaderProgram.cpp
@@ -1,5 +1,10 @@
 #include "ShaderProgram.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-volatile"
+#include <glm/gtc/type_ptr.hpp>
+#pragma clang diagnostic pop
+
 #include <string>
 #include <sstream>
 #include <vector>
@@ -49,7 +54,29 @@ ShaderProgram::~ShaderProgram()
     _gl.DeleteProgram(_handle);
 }
 
-GLuint ShaderProgram::Handle()
+void ShaderProgram::Use()
 {
-    return _handle;
+    _gl.UseProgram(_handle);
+}
+
+void ShaderProgram::SetUniform(const std::string name, int value)
+{
+    _gl.Uniform1i(_gl.GetUniformLocation(_handle, name.c_str()), value);
+}
+
+void ShaderProgram::SetUniform(const std::string name, const glm::mat4& value)
+{
+    _gl.UniformMatrix4fv(
+        _gl.GetUniformLocation(_handle, name.c_str()),
+        1,
+        false,
+        glm::value_ptr(value));
+}
+
+void ShaderProgram::SetUniform(const std::string name, const glm::vec3& value)
+{
+    _gl.Uniform3fv(
+        _gl.GetUniformLocation(_handle, name.c_str()),
+        1,
+        glm::value_ptr(value));
 }

--- a/src/Graphics/OpenGL/ShaderProgram.h
+++ b/src/Graphics/OpenGL/ShaderProgram.h
@@ -1,6 +1,13 @@
 #pragma once
 
 #include <initializer_list>
+#include <string>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-volatile"
+#include <glm/mat4x4.hpp>
+#include <glm/vec3.hpp>
+#pragma clang diagnostic pop
 
 #include "IShader.h"
 #include "IOpenGLWrapper.h"
@@ -14,7 +21,10 @@ namespace Graphics::OpenGL
         ~ShaderProgram();
         ShaderProgram(const ShaderProgram&) = delete;
 
-        GLuint Handle();
+        void Use();
+        void SetUniform(const std::string name, int value);
+        void SetUniform(const std::string name, const glm::mat4& value);
+        void SetUniform(const std::string name, const glm::vec3& value);
 
     private:
         IOpenGLWrapper& _gl;

--- a/src/GraphicsIntegrationTests/OpenGL/ShaderProgramTests.cpp
+++ b/src/GraphicsIntegrationTests/OpenGL/ShaderProgramTests.cpp
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 
+
 #include "Graphics/OpenGL/ShaderProgram.h"
 #include "Graphics/OpenGL/Shader.h"
 #include "Graphics/OpenGL/GlfwWrapper.h"
@@ -21,13 +22,23 @@ public:
           _glfw(),
           _window(_glfw, 800, 600, "DummyIntegrationTestWindow")
     {
-
+        // clear errors
+        _gl.GetError();
     }
 protected:
     OpenGLWrapper _gl;
     GlfwWrapper _glfw;
     Window _window;
+
 };
+
+namespace
+{
+    void AssertNoOpenGLErrors(IOpenGLWrapper& gl)
+    {
+        EXPECT_EQ(gl.GetError(), static_cast<unsigned int>(GL_NO_ERROR));
+    }
+}
 
 TEST_F(ShaderProgramTests, CreateShaderProgramSuccess)
 {
@@ -37,8 +48,48 @@ TEST_F(ShaderProgramTests, CreateShaderProgramSuccess)
     Shader fragmentShader(gl, Shader::Type::Fragment, GetValidFragmentShaderCode());
     EXPECT_NO_THROW(
         ShaderProgram shaderProgram(gl, {&vertexShader, &fragmentShader});
-        EXPECT_NE(shaderProgram.Handle(), (GLuint)0)
+        shaderProgram.Use();
     );
+}
+
+TEST_F(ShaderProgramTests, SetVertexShaderUniforms)
+{
+    OpenGLWrapper gl;
+
+    Shader vertexShader(gl, Shader::Type::Vertex, GetVertexShaderCodeWithUniforms());
+    Shader fragmentShader(gl, Shader::Type::Fragment, GetValidFragmentShaderCode());
+    ShaderProgram shaderProgram(gl, {&vertexShader, &fragmentShader});
+
+    AssertNoOpenGLErrors(gl);
+
+    shaderProgram.Use();
+    AssertNoOpenGLErrors(gl);
+    shaderProgram.SetUniform("testMatrix4", glm::mat4());
+    AssertNoOpenGLErrors(gl);
+    shaderProgram.SetUniform("testSampler", 123);
+    AssertNoOpenGLErrors(gl);
+    shaderProgram.SetUniform("testVector3", glm::vec3());
+    AssertNoOpenGLErrors(gl);
+}
+
+TEST_F(ShaderProgramTests, SetFragmentShaderUniforms)
+{
+    OpenGLWrapper gl;
+
+    Shader vertexShader(gl, Shader::Type::Vertex, GetValidVertexShaderCode());
+    Shader fragmentShader(gl, Shader::Type::Fragment, GetFragmentShaderCodeWithUniforms());
+    ShaderProgram shaderProgram(gl, {&vertexShader, &fragmentShader});
+
+    AssertNoOpenGLErrors(gl);
+
+    shaderProgram.Use();
+    AssertNoOpenGLErrors(gl);
+    shaderProgram.SetUniform("testMatrix4", glm::mat4());
+    AssertNoOpenGLErrors(gl);
+    shaderProgram.SetUniform("testSampler", 123);
+    AssertNoOpenGLErrors(gl);
+    shaderProgram.SetUniform("testVector3", glm::vec3());
+    AssertNoOpenGLErrors(gl);
 }
 
 // In the future maybe write a test that intentionally

--- a/src/GraphicsIntegrationTests/OpenGL/TestHelpers.cpp
+++ b/src/GraphicsIntegrationTests/OpenGL/TestHelpers.cpp
@@ -23,3 +23,33 @@ std::string GetValidFragmentShaderCode()
         }
         )##RAW##";
 }
+
+std::string GetVertexShaderCodeWithUniforms()
+{
+    return R"##RAW##(
+        #version 330 core
+        layout (location = 0) in vec3 aPos;
+        uniform mat4 testMatrix4;
+        uniform sampler2D testSampler;
+        uniform vec3 testVector3;
+        void main()
+        {
+            gl_Position = vec4(aPos.x, aPos.y, aPos.z, 1.0);
+        }
+        )##RAW##";
+}
+
+std::string GetFragmentShaderCodeWithUniforms()
+{
+    return R"##RAW##(
+        #version 330 core
+        out vec4 FragColor;
+        uniform mat4 testMatrix4;
+        uniform sampler2D testSampler;
+        uniform vec3 testVector3;
+        void main()
+        {
+            FragColor = vec4(1.0f, 0.5f, 0.2f, 1.0f);
+        }
+        )##RAW##";
+}

--- a/src/GraphicsIntegrationTests/OpenGL/TestHelpers.h
+++ b/src/GraphicsIntegrationTests/OpenGL/TestHelpers.h
@@ -2,3 +2,5 @@
 
 std::string GetValidVertexShaderCode();
 std::string GetValidFragmentShaderCode();
+std::string GetVertexShaderCodeWithUniforms();
+std::string GetFragmentShaderCodeWithUniforms();

--- a/src/GraphicsUnitTests/OpenGL/MockOpenGLWrapper.h
+++ b/src/GraphicsUnitTests/OpenGL/MockOpenGLWrapper.h
@@ -20,6 +20,11 @@ public:
     MOCK_METHOD(void, GetProgramiv, (GLuint program, GLenum pname, GLint *params), (override));
     MOCK_METHOD(void, GetProgramInfoLog, (GLuint program, GLsizei maxLength, GLsizei* length, GLchar* infoLog), (override));
     MOCK_METHOD(void, DeleteProgram, (GLuint program), (override));
+    MOCK_METHOD(void, UseProgram, (GLuint program), (override));
+    MOCK_METHOD(GLint, GetUniformLocation, (GLuint program, const GLchar* location), (override));
+    MOCK_METHOD(void, Uniform1i, (GLint location, GLint v0), (override));
+    MOCK_METHOD(void, UniformMatrix4fv, (GLint location, GLsizei count, GLboolean transpose, const GLfloat *value), (override));
+    MOCK_METHOD(void, Uniform3fv, (GLint location, GLsizei count, const GLfloat *value), (override));
     MOCK_METHOD(void, GenVertexArrays, (GLsizei n, GLuint *arrays), (override));
     MOCK_METHOD(void, GenTextures, (GLsizei n, GLuint* textures), (override));
     MOCK_METHOD(void, DeleteTextures, (GLsizei n, const GLuint* textures), (override));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,8 +95,7 @@ int main()
         glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
         glClear(GL_COLOR_BUFFER_BIT);
 
-
-        glUseProgram(shaderProgram.Handle());
+        shaderProgram.Use();
         glBindVertexArray(VAO); // seeing as we only have a single VAO there's no need to bind it every time, but we'll do so to keep things a bit more organized
         //glDrawArrays(GL_TRIANGLES, 0, 6);
         glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);


### PR DESCRIPTION
Remove Handle() method because any methods that need to be performed with the ShaderProgram can likely be added to the class.